### PR TITLE
Fix issue with prices not correct for current selected variant

### DIFF
--- a/templates/product.3_0_0-others.liquid
+++ b/templates/product.3_0_0-others.liquid
@@ -143,10 +143,10 @@
                                     {% if product.compare_at_price > product.price %}
                                     <span class="compare-price">{{ product.compare_at_price_max | money }}</span>
                                     <span class="price on-sale" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                     {% else %}
                                     <span class="price" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                     {% endif %}
                                     {% if product.available %}
                                     <link itemprop="availability" href="http://schema.org/InStock">

--- a/templates/product.3_0_0.liquid
+++ b/templates/product.3_0_0.liquid
@@ -343,10 +343,10 @@
                                             {% if product.compare_at_price > product.price %}
                                                 <span class="compare-price">{{ product.compare_at_price_max | money }}</span>
                                                 <span class="price on-sale" itemprop="price"
-                                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                             {% else %}
                                                 <span class="price" itemprop="price"
-                                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                             {% endif %}
                                             {% if product.available %}
                                                 <link itemprop="availability"

--- a/templates/product.3_1.liquid
+++ b/templates/product.3_1.liquid
@@ -415,10 +415,10 @@
                                     {% if product.compare_at_price > product.price %}
                                     <span class="compare-price">{{ product.compare_at_price_max | money_without_trailing_zeros}}</span>
                                     <span class="price on-sale" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros}}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                     {% else %}
                                     <span class="price" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros }}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                     {% endif %}
                                     {% if product.available %}
                                     <link itemprop="availability"

--- a/templates/product.3_1_bamboo.liquid
+++ b/templates/product.3_1_bamboo.liquid
@@ -408,9 +408,9 @@
                                     <meta itemprop="priceCurrency" content="{{ shop.currency }}">
                                     {% if product.compare_at_price > product.price %}
                                         <span class="compare-price">{{ product.compare_at_price_max | money_without_trailing_zeros}}</span>
-                                        <span class="price on-sale" itemprop="price" content="{{ current_variant.price | divided_by: 100.00 }}">{{ current_variant.price | money_without_trailing_zeros}}</span>
+                                        <span class="price on-sale" itemprop="price" content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ current_variant.price | money_without_trailing_zeros}}</span>
                                     {% else %}
-                                        <span class="price" itemprop="price" content="{{ current_variant.price | divided_by: 100.00 }}">{{ current_variant.price | money_without_trailing_zeros }}</span>
+                                        <span class="price" itemprop="price" content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ current_variant.price | money_without_trailing_zeros }}</span>
                                     {% endif %}
                                     {% if product.available %}
                                         <link itemprop="availability" href="http://schema.org/InStock">

--- a/templates/product.3_1_cedarluxe.liquid
+++ b/templates/product.3_1_cedarluxe.liquid
@@ -414,10 +414,10 @@
                                 {% if product.compare_at_price > product.price %}
                                 <span class="compare-price">{{ product.compare_at_price_max | money_without_trailing_zeros}}</span>
                                 <span class="price on-sale" itemprop="price"
-                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros}}</span>
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                 {% else %}
                                 <span class="price" itemprop="price"
-                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros }}</span>
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                 {% endif %}
                                 {% if product.available %}
                                 <link itemprop="availability"

--- a/templates/product.3_1_cedarluxe2.liquid
+++ b/templates/product.3_1_cedarluxe2.liquid
@@ -132,10 +132,10 @@
                                     {% if product.compare_at_price > product.price %}
                                     <span class="compare-price">{{ product.compare_at_price_max | money }}</span>
                                     <span class="price on-sale" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                     {% else %}
                                     <span class="price" itemprop="price"
-                                          content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                                          content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                     {% endif %}
                                     {% if product.available %}
                                     <link itemprop="availability"

--- a/templates/product.3_1_oceano.liquid
+++ b/templates/product.3_1_oceano.liquid
@@ -625,10 +625,10 @@
                                 {% if product.compare_at_price > product.price %}
                                 <span class="compare-price">{{ product.compare_at_price_max | money_without_trailing_zeros}}</span>
                                 <span class="price on-sale" itemprop="price"
-                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros}}</span>
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                 {% else %}
                                 <span class="price" itemprop="price"
-                                      content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money_without_trailing_zeros }}</span>
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                 {% endif %}
                                 {% if product.available %}
                                 <link itemprop="availability"

--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -106,9 +106,11 @@
                               <meta itemprop="priceCurrency" content="{{ shop.currency }}">
                               {% if product.compare_at_price > product.price %}
                               <span class="compare-price">{{ product.compare_at_price_max | money }}</span>
-                              <span class="price on-sale" itemprop="price" content="{{ product.price | money_without_currency | remove: ',' }}">{{ product.price | money }}</span>
+                              <span class="price on-sale" itemprop="price"
+                                    content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                               {% else %}
-                              <span class="price" itemprop="price" content="{{ product.price | money_without_currency }}">{{ product.price | money_without_trailing_zeros }}</span>
+                              <span class="price" itemprop="price"
+                                    content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                               {% endif %}
                               {% if product.available %}
                               <link itemprop="availability" href="http://schema.org/InStock">

--- a/templates/product.productshowcasev1.liquid
+++ b/templates/product.productshowcasev1.liquid
@@ -131,10 +131,11 @@
                             <div class="prices" style="float: right;">
                                 {% if product.compare_at_price > product.price %}
                                 <span class="compare-price">{{ product.compare_at_price_max | money }}</span>
-                                <span class="price on-sale" itemprop="price">{{ product.price | money }}</span>
+                                <span class="price on-sale" itemprop="price"
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros}}</span>
                                 {% else %}
-                                <span itemprop="priceCurrency" content="{{ shop.currency }}"></span>
-                                <span class="price" itemprop="price" content="{{ product.price | money_without_currency }}">{{ product.price | money_without_trailing_zeros }}</span>
+                                <span class="price" itemprop="price"
+                                      content="{{ product.selected_or_first_available_variant.price | money_without_currency | remove: ',' }}">{{ product.selected_or_first_available_variant.price | money_without_trailing_zeros }}</span>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
This should hopefully feed in the correct prices into the Google Product Feed, I've checked every product's HTML source and they seem to have the right prices. :+1: 

The theme is also at: https://brentwood-home.myshopify.com/admin/themes/50556895294